### PR TITLE
Move map rendering into a View

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -28,6 +28,7 @@
       <a id="go-leaderboards" href="">Leaders</a>
     </nav>
   </div>
+  <div id="map"></div>
   <div id="gps-status"></div>
   <footer>
     <p>© 2013 RouteMaster</p>
@@ -72,7 +73,6 @@
     {{^isTracking}}
       <p>Press "Start" to begin.</p>
     {{/isTracking}}
-    <div id="map"></div>
   </section>
 </script>
 


### PR DESCRIPTION
The map rendering was being done in our GpsTracker model. Models are for data: not display. This makes a new `MapView` view and an extended `GpsMapView` which interfaces with `GpsTracker` model.

Some niceties were added as well: an accuracy circle, adjusted zoom levels, and auto-updating the map as you walk (not tested).
