### PR TITLE
Show maps on the history view

### DIFF
--- a/config/jshint.json
+++ b/config/jshint.json
@@ -1,0 +1,11 @@
+{
+    "camelcase": true,
+    "eqeqeq": true,
+    "maxlen": 80,
+    "es5": true,
+    "strict": true,
+    "trailing": true,
+    "browser": true,
+    "jquery": true,
+    "devel": true
+}

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -5,7 +5,9 @@ define("history", function(require) {
         _ = require("underscore"),
         $ = require("jquery"),
         Mustache = require("mustache"),
-        list = require("list");
+        list = require("list"),
+        L = require("leaflet"),
+        map = require("map");
 
     var Route = Backbone.Model.extend({
         defaults: {
@@ -13,10 +15,51 @@ define("history", function(require) {
             endName: undefined,
             date: undefined,
             distance: undefined,
-            efficiency: undefined
+            efficiency: undefined,
+            waypoints: undefined
         },
-        url: '/route/'
+
+        url: '/route/',
+
+        initialize: function() {
+            // Fetch the waypoints from the server
+            var Waypoints = Backbone.Collection.extend({
+                url: "/route/" + this.id + "/waypoints/"
+            });
+            this.waypoints = new Waypoints();
+            this.waypoints.fetch({
+                success: _.bind(function(collection, response, options) {
+                    this.drawPath();
+                }, this),
+                error: function() {
+                    console.log(arguments);
+                }
+            });
+        }
     });
 
-    return { Route: Route };
+    var RouteItemView = list.ListElementView.extend({
+        initialize: function() {
+            list.ListElementView.prototype.initialize.apply(this, _.toArray(arguments));
+            this.map = new map.MapView({
+                el: $("<div/>").appendTo(this.$el)
+            });
+        },
+
+        render: function() {
+            // Add path to the leaflet map
+            var points = [];
+            _.each(this.model.waypoints, function(waypoint) {
+                points.push([waypoint.latitude, waypoint.longitude]);
+            });
+            var polyline = L.polyline(points).addTo(this.map.leafletMap);
+            // Zoom the map to the area containing the path
+            this.map.leafletMap.fitBounds(polyline.getBounds());
+        }
+    });
+
+    return {
+        Route: Route,
+        RouteItemView: RouteItemView
+    };
 });

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -27,14 +27,7 @@ define("history", function(require) {
                 url: "/route/" + this.id + "/waypoints/"
             });
             this.waypoints = new Waypoints();
-            this.waypoints.fetch({
-                success: _.bind(function(collection, response, options) {
-                    this.drawPath();
-                }, this),
-                error: function() {
-                    console.log(arguments);
-                }
-            });
+            this.waypoints.fetch();
         }
     });
 
@@ -43,19 +36,29 @@ define("history", function(require) {
             list.ListElementView.prototype.initialize.apply(
                 this, _.toArray(arguments));
             this.map = new map.MapView({
-                el: $("<div/>").appendTo(this.$el)
+                el: $("<div/>")
             });
         },
 
-        render: function() {
+        drawPath: function() {
             // Add path to the leaflet map
             var points = [];
-            _.each(this.model.waypoints, function(waypoint) {
-                points.push([waypoint.latitude, waypoint.longitude]);
+            _.each(this.model.waypoints.models, function(waypoint) {
+                var w = waypoint.attributes;
+                points.push([w.latitude, w.longitude]);
             });
             var polyline = L.polyline(points).addTo(this.map.leafletMap);
             // Zoom the map to the area containing the path
             this.map.leafletMap.fitBounds(polyline.getBounds());
+        },
+
+        render: function() {
+            this.$el.html(this.shortTemplate(this.model.attributes));
+            if(this.expanded) {
+                this.$el.append(this.expandedTemplate(this.model.attributes));
+                this.$el.append(this.map.el);
+                this.drawPath();
+            }
         }
     });
 

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -40,7 +40,8 @@ define("history", function(require) {
 
     var RouteItemView = list.ListElementView.extend({
         initialize: function() {
-            list.ListElementView.prototype.initialize.apply(this, _.toArray(arguments));
+            list.ListElementView.prototype.initialize.apply(
+                this, _.toArray(arguments));
             this.map = new map.MapView({
                 el: $("<div/>").appendTo(this.$el)
             });

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -68,7 +68,8 @@ define("history", function(require) {
                 expandedElement.append(this.map.$el);
                 // zooming must happen after map is drawn (so that leaflet can
                 // figure out the size of the map it's working with)
-                _.defer(_.bind(this.zoomPath, this));
+                this.map.fixMapDisplay();
+                this.zoomPath();
             } else {
                 this.map = undefined;
             }

--- a/src/js/list.js
+++ b/src/js/list.js
@@ -42,6 +42,7 @@ define("list", function(require) {
         initialize: function(options) {
             this.shortTemplate = options.shortTemplate;
             this.expandedTemplate = options.expandedTemplate;
+            this.itemView = options.itemView;
             this.$ol = $('<ol/>').addClass("listing");
         },
 
@@ -51,7 +52,7 @@ define("list", function(require) {
             this.collection.each(function(model) {
                 var $li = $('<li/>');
                 this.$ol.append($li);
-                this.subViews.push(new ListElementView({
+                this.subViews.push(new this.itemView({
                     el: $li,
                     model: model,
                     shortTemplate: this.shortTemplate,
@@ -66,5 +67,8 @@ define("list", function(require) {
         }
     });
 
-    return { ListView: ListView };
+    return {
+        ListView: ListView,
+        ListElementView: ListElementView
+    };
 });

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -60,8 +60,7 @@ define("map", function(require) {
 
         // Due to a bug in leaflet: http://stackoverflow.com/q/10762984/130598
         fixMapDisplay: function() {
-            var map = this.leafletMap;
-            L.Util.requestAnimFrame(map.invalidateSize,map,!1,map._container);
+            this.leafletMap.invalidateSize(false);
         },
 
         close: function() {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -12,19 +12,34 @@ define("map", function(require) {
         osmAttr: "&copy;" + (new Date()).getFullYear() +
                  " OpenStreetMap Contributors",
 
-        initialize: function() {
+        // settings that get overridden when we're in "static" mode
+        staticOptions: {
+            dragging: false,
+            touchZoom: false,
+            scrollWheelZoom: false,
+            doubleClickZoom: false,
+            boxZoom: false,
+            closePopupOnClick: false,
+            keyboard: false,
+            zoomControl: false
+        },
+
+        initialize: function(options) {
+            options = _.defaults(options, {
+                isStatic: false
+            });
             this.osm = new L.TileLayer(this.osmUrl, {
                 attribution: this.osmAttr,
                 maxZoom: 17,
                 minZoom: 8
             });
-            this.leafletMap = new L.Map(this.el, {
+            this.leafletMap = new L.Map(this.el, _.extend({
                 layers: [this.osm],
                 zoom: 16,
                 // hide zoom controls on multitouch devices
                 zoomControl: !L.Browser.touch || L.Browser.android23,
                 center: [51.505, -0.09]
-            });
+            }, options.isStatic ? this.staticOptions : {}));
             // hide the "powered by Leaflet" text
             this.leafletMap.attributionControl.setPrefix(false);
             // Apply any css we might have for `.map`

--- a/src/js/urlHandler.js
+++ b/src/js/urlHandler.js
@@ -99,7 +99,8 @@ define("urlHandler", function(require) {
                 ),
                 expandedTemplate: Mustache.compile(
                     $("#route-item-expanded-templ").html()
-                )
+                ),
+                itemView: history.RouteItemView
             });
             routes.fetch({
                 success: _.bind(function(collection, response, options) {

--- a/src/sass/global.sass
+++ b/src/sass/global.sass
@@ -193,6 +193,6 @@ button, a.button
     +text-inset($lighttext)
 
 // Leaflet Map
-#track>.map
+.leaflet-container
     height: 240px
     margin: 0.2em 0

--- a/src/sass/global.sass
+++ b/src/sass/global.sass
@@ -196,3 +196,7 @@ button, a.button
 .leaflet-container
     height: 240px
     margin: 0.2em 0
+    // reset some properties that might have been set
+    border-radius: 0
+    color: black
+    text-shadow: none


### PR DESCRIPTION
Seems to be working, except for a small bug. The first route I open after switching to the History tab is fine, but for subsequent routes the map doesn't zoom in to the area containing the path. A work-around is to click the History tab again before opening each route.
